### PR TITLE
feat(connect-alb-istio): add alb ingress definition

### DIFF
--- a/helm/templates/connect-alb-to-istio.yaml
+++ b/helm/templates/connect-alb-to-istio.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.connectAlbToIstio.enable }}
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: rancher-istio
+  namespace: argocd
+  annotations:
+    argocd.argoproj.io/sync-wave: "7"
+  finalizers:
+  - resources-finalizer.argocd.argoproj.io
+spec:
+  destination:
+    server: 'https://kubernetes.default.svc'
+    namespace: istio-system
+  project: default
+  source:
+    repoURL: https://kloia.github.io/charts/
+    chart: aws-alb-ingress
+    targetRevision: {{ .Values.connectAlbToIstio.targetRevision }}
+    {{- if .Values.connectAlbToIstio.values }}
+    helm:
+      {{- if .Values.connectAlbToIstio.values }}
+      values: |
+        {{ .Values.connectAlbToIstio.values | toYaml | indent 8 | trim}}
+      {{- end }}
+    {{- end }}
+  syncPolicy:
+    syncOptions:
+      - CreateNamespace=true
+      - Replace=true
+    automated:
+      prune: true
+      selfHeal: true
+{{- end }}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -50,3 +50,51 @@ rancherIstio:
     tracing:
       enabled: true
 
+connectAlbToIstio:
+  enable: false
+  targetRevision: "0.2.0"
+  values:
+    name: connect-alb-to-istio
+    alb:
+      # when using, make sure to add certificate
+      scheme: internet-facing
+      target-type: instance
+      backend-protocol: HTTPS
+      healthcheck-path: "/healthz/ready"
+      healthcheck-protocol: HTTP
+      listen-ports:
+        - HTTP: 80
+        - HTTPS: 443
+      actions.ssl-redirect:
+        Type: redirect
+        RedirectConfig:
+          Protocol: HTTPS
+          Port: "443"
+          StatusCode: HTTP_301
+    spec:
+      ingressClassName: alb
+      rules:
+        - http:
+          paths:
+            - backend:
+              service:
+                name: ssl-redirect
+                port:
+                  name: use-annotation
+              path: /
+              pathType: Prefix
+            - backend:
+              service:
+                name: istio-ingressgateway
+                port:
+                  number: 15021
+              path: /healthz/ready
+              pathType: Prefix
+            - backend:
+              service:
+                name: istio-ingressgateway
+                port:
+                  number: 443
+              path: /
+              pathType: Prefix
+


### PR DESCRIPTION
Use the chart kloia/aws-alb-ingress for setting up the routing from AWS ALB to Istio with annotated ingress