### PR TITLE
feat: common rancher versioning

### DIFF
--- a/helm/templates/rancher-istio.yaml
+++ b/helm/templates/rancher-istio.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     repoURL: https://github.com/rancher/charts.git
     path: charts/rancher-istio/{{ .Values.rancherIstio.version }}/
-    targetRevision: {{ .Values.rancherIstio.chartsRepoTargetRevision }}
+    targetRevision: release-{{ .Values.rancher.targetRevision }}
     {{- if .Values.rancherIstio.values }}
     helm:
       {{- if .Values.rancherIstio.values }}

--- a/helm/templates/rancher-monitoring-crd.yaml
+++ b/helm/templates/rancher-monitoring-crd.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     repoURL: https://github.com/rancher/charts.git
     path: charts/rancher-monitoring-crd/{{ .Values.rancherMonitoringCrd.version }}/
-    targetRevision: {{ .Values.rancherMonitoringCrd.chartsRepoTargetRevision }}
+    targetRevision: release-{{ .Values.rancher.targetRevision }}
     {{- if .Values.rancherMonitoringCrd.values }}
     helm:
       {{- if .Values.rancherMonitoringCrd.values }}

--- a/helm/templates/rancher-monitoring.yaml
+++ b/helm/templates/rancher-monitoring.yaml
@@ -16,7 +16,7 @@ spec:
   source:
     repoURL: https://github.com/rancher/charts.git
     path: charts/rancher-monitoring/{{ .Values.rancherMonitoring.version }}/
-    targetRevision: {{ .Values.rancherMonitoring.chartsRepoTargetRevision }}
+    targetRevision: release-{{ .Values.rancher.targetRevision }}
     {{- if .Values.rancherMonitoring.values }}
     helm:
       {{- if .Values.rancherMonitoring.values }}

--- a/helm/templates/rancher.yaml
+++ b/helm/templates/rancher.yaml
@@ -12,7 +12,7 @@ spec:
   project: default
   source:
     repoURL: 'https://releases.rancher.com/server-charts/stable'
-    targetRevision: v2.7.4
+    targetRevision: {{ .Values.rancher.targetRevision }}
     helm:
       values: |
         {{ .Values.rancher.values | toYaml | indent 8 | trim}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -31,6 +31,7 @@ certManager:
         honorLabels: "false"
 rancher:
   enable: false
+  targetRevision: v2.7.4
   values:
     hostname: "rancher.kloia.com"
     tls: "external"
@@ -39,16 +40,13 @@ rancher:
       ingressClassName: "nginx"
 rancherMonitoringCrd:
   enable: false
-  chartsRepoTargetRevision: "dev-v2.7"
-  version: "102.0.1+up40.1.2"
+  version: "102.0.0+up40.1.2"
 rancherMonitoring:
   enable: false
-  chartsRepoTargetRevision: "release-v2.7"
   version: "102.0.0+up40.1.2"
 rancherIstio:
   enable: false
-  chartsRepoTargetRevision: "dev-v2.7"
-  version: "102.0.1+up40.1.2"
+  version: "102.2.0+up1.17.2"
   values:
     tracing:
       enabled: true


### PR DESCRIPTION
Uses common targetRevision of the rancher
chart to source versions of extra charts from
`release-{targetRevision}` branches.
